### PR TITLE
Update package.json

### DIFF
--- a/DevelopmentProcess/eslint-env/package.json
+++ b/DevelopmentProcess/eslint-env/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "@enterthenamehere/esdoc-standard-plugin": "^2.2.4",
-    "esdoc": "^1.1.0"
+    "@enterthenamehere/esdoc": "^2.2.4"
   }
 }


### PR DESCRIPTION
Hi, I don't see any way to write you, so I try it this way:

esdoc is no longer maintained, so I made my own fork and updated it for modern javascript (see https://github.com/EnterTheNameHere/esdoc-monorepo/tree/main/ )

@enterthenamehere/esdoc-standard-plugin cannot be used with original esdoc.
If you plan to use it, you need to install @enterthenamehere/esdoc instead of esdoc.

However ESLint and esdoc are different projects, ESLint is linter, esdoc is documentation generator, like jsdoc. It has no relation with ESLint, in case you just wanted to write about ESLint and is not required at all.

BTW great manual!